### PR TITLE
Aligner: use FreeCAD transaction for Align button

### DIFF
--- a/Aligner.py
+++ b/Aligner.py
@@ -746,7 +746,9 @@ class Ui_DockWidget(object):
             cy=1
         if self.cbZ.isChecked():
             cz=1
+        FreeCAD.ActiveDocument.openTransaction('Align')
         Align(normal,type,mode,cx,cy,cz)
+        FreeCAD.ActiveDocument.commitTransaction()
         if len (objs_moved) > 0:
             self.Undo_Align.setEnabled(True)
         else:


### PR DESCRIPTION
just an example. 
I didn't go to the effort of adding to all buttons, and to redirect aligner's undo button to use FC transactions/remove button altogether.