### PR TITLE
Correct classname in package.xml

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -10,7 +10,7 @@
 
   <content>
     <workbench>
-      <classname>Manipulator Workbench</classname>
+      <classname>ManipulatorWB</classname>
       <subdirectory>./</subdirectory>
       <freecadmin>0.17.0</freecadmin>
       <tag>Move</tag>


### PR DESCRIPTION
The entry class in InitGui.py is called `ManipulatorWB`.